### PR TITLE
Fix: WxPay 接口会删除 option 上的 key, 加上 dup 避免此问题

### DIFF
--- a/app/models/payment_interface/rails_trade_wxpay.rb
+++ b/app/models/payment_interface/rails_trade_wxpay.rb
@@ -7,7 +7,6 @@ module RailsTradeWxpay
   end
 
   def wxpay_prepay(trade_type = 'JSAPI', options = {})
-    return @wxpay_prepay if defined?(@wxpay_prepay)
     params = {
       body: "订单编号: #{self.uuid}",
       out_trade_no: self.uuid,
@@ -17,31 +16,30 @@ module RailsTradeWxpay
       trade_type: trade_type,
     }
     params.merge!(openid: openid) if openid
-    @wxpay_prepay = WxPay::Service.invoke_unifiedorder params, options
+    WxPay::Service.invoke_unifiedorder params, options.dup
   end
 
   def wxpay_order(trade_type = 'JSAPI', options = {})
-    return @wxpay_order if defined?(@wxpay_order)
-
     prepay = wxpay_prepay(trade_type, options)
+
+    return { return_code: prepay[:return_code], return_msg: prepay[:return_msg] } unless prepay.success?
+
     if prepay['result_code'] == 'SUCCESS'
       params = {
         noncestr: prepay['nonce_str'],
         prepayid: prepay['prepay_id']
       }
       if trade_type == 'JSAPI'
-        @wxpay_order = WxPay::Service.generate_js_pay_req params, options
+        WxPay::Service.generate_js_pay_req params, options.dup
       else
-        @wxpay_order = WxPay::Service.generate_app_pay_req params, options
+        WxPay::Service.generate_app_pay_req params, options.dup
       end
     elsif prepay['result_code'] == 'FAIL'
-      @wxpay_order = {
+      {
         result_code: 'FAIL',
         err_code: prepay['err_code'],
         err_code_des: prepay['err_code_des']
       }
-    else
-      @wxpay_order = {}
     end
   end
 


### PR DESCRIPTION
另外，不宜缓存微信预付单。做缓存的话需要考虑参数的值